### PR TITLE
Use lookups to determine the clusterPlatform

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -45,7 +45,7 @@ Default always defined valueFiles to be included when pushing the cluster wide a
 - name: global.localClusterName
   value: '{{ `{{ (split "." (lookup "config.openshift.io/v1" "Ingress" "" "cluster").spec.domain)._1 }}` }}'
 - name: global.clusterPlatform
-  value: {{ $.Values.global.clusterPlatform }}
+  value: '{{ `{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}` }}'
 - name: global.multiSourceSupport
   value: {{ $.Values.global.multiSourceSupport | quote }}
 - name: global.multiSourceRepoUrl


### PR DESCRIPTION
Right now we set global.clusterPlatform to whatever helm passes on, but
this is conceptually not correct:

        - name: global.clusterPlatform
          value: {{ $.Values.global.clusterPlatform }}

If the hub is on AWS and a spoke on Azure, the clusterPlatform on the
spoke needs to look it up locally, otherwise we can't do mixed
platforms.

Tested this on baremetal (where it was both None on hub and spoke) and
on AWS. The lookup works correctly so this should fix things properly.

Closes: #17
