### PR TITLE
Allow for extra HealthChecks for argo

### DIFF
--- a/templates/policies/ocp-gitops-policy.yaml
+++ b/templates/policies/ocp-gitops-policy.yaml
@@ -271,6 +271,12 @@ spec:
                       kind: Subscription
                       check: |
 {{- include "acm.subscription.healthcheck.lua" . | nindent 24 }}
+{{- range $.Values.acm.extraResourceHealthChecks }}
+                    - group: {{ .group }}
+                      kind: {{ .kind }}
+                      check: |
+{{ .check | nindent 24 }}
+{{- end }}
                   server:
                     autoscale:
                       enabled: false

--- a/tests/ocp_gitops_policy_test.yaml
+++ b/tests/ocp_gitops_policy_test.yaml
@@ -95,3 +95,110 @@ tests:
         equal:
           path: spec.policy-templates[0].objectDefinition.spec.object-templates[0].objectDefinition.spec.channel
           value: gitops-priority
+
+  - it: Should have only the default Subscription healthcheck when no extra healthchecks are configured
+    values:
+      - ./clusterselector_values.yaml
+    asserts:
+      - documentSelector:
+          path: metadata.name
+          value: group-one-gitops-policy-argocd
+        lengthEqual:
+          path: spec.policy-templates[0].objectDefinition.spec.object-templates[0].objectDefinition.spec.resourceHealthChecks
+          count: 1
+      - documentSelector:
+          path: metadata.name
+          value: group-one-gitops-policy-argocd
+        equal:
+          path: spec.policy-templates[0].objectDefinition.spec.object-templates[0].objectDefinition.spec.resourceHealthChecks[0].group
+          value: operators.coreos.com
+      - documentSelector:
+          path: metadata.name
+          value: group-one-gitops-policy-argocd
+        equal:
+          path: spec.policy-templates[0].objectDefinition.spec.object-templates[0].objectDefinition.spec.resourceHealthChecks[0].kind
+          value: Subscription
+
+  - it: Should append a single extra resource healthcheck
+    values:
+      - ./clusterselector_values.yaml
+    set:
+      acm:
+        extraResourceHealthChecks:
+          - group: argoproj.io
+            kind: Application
+            check: |
+              hs = {}
+              hs.status = "Healthy"
+              return hs
+    asserts:
+      - documentSelector:
+          path: metadata.name
+          value: group-one-gitops-policy-argocd
+        lengthEqual:
+          path: spec.policy-templates[0].objectDefinition.spec.object-templates[0].objectDefinition.spec.resourceHealthChecks
+          count: 2
+      - documentSelector:
+          path: metadata.name
+          value: group-one-gitops-policy-argocd
+        equal:
+          path: spec.policy-templates[0].objectDefinition.spec.object-templates[0].objectDefinition.spec.resourceHealthChecks[0].group
+          value: operators.coreos.com
+      - documentSelector:
+          path: metadata.name
+          value: group-one-gitops-policy-argocd
+        equal:
+          path: spec.policy-templates[0].objectDefinition.spec.object-templates[0].objectDefinition.spec.resourceHealthChecks[1].group
+          value: argoproj.io
+      - documentSelector:
+          path: metadata.name
+          value: group-one-gitops-policy-argocd
+        equal:
+          path: spec.policy-templates[0].objectDefinition.spec.object-templates[0].objectDefinition.spec.resourceHealthChecks[1].kind
+          value: Application
+
+  - it: Should append multiple extra resource healthchecks
+    values:
+      - ./clusterselector_values.yaml
+    set:
+      acm:
+        extraResourceHealthChecks:
+          - group: argoproj.io
+            kind: Application
+            check: |
+              hs = {}
+              hs.status = "Healthy"
+              return hs
+          - group: batch
+            kind: Job
+            check: |
+              hs = {}
+              if obj.status.succeeded == 1 then
+                hs.status = "Healthy"
+              end
+              return hs
+    asserts:
+      - documentSelector:
+          path: metadata.name
+          value: group-one-gitops-policy-argocd
+        lengthEqual:
+          path: spec.policy-templates[0].objectDefinition.spec.object-templates[0].objectDefinition.spec.resourceHealthChecks
+          count: 3
+      - documentSelector:
+          path: metadata.name
+          value: group-one-gitops-policy-argocd
+        equal:
+          path: spec.policy-templates[0].objectDefinition.spec.object-templates[0].objectDefinition.spec.resourceHealthChecks[1].group
+          value: argoproj.io
+      - documentSelector:
+          path: metadata.name
+          value: group-one-gitops-policy-argocd
+        equal:
+          path: spec.policy-templates[0].objectDefinition.spec.object-templates[0].objectDefinition.spec.resourceHealthChecks[2].group
+          value: batch
+      - documentSelector:
+          path: metadata.name
+          value: group-one-gitops-policy-argocd
+        equal:
+          path: spec.policy-templates[0].objectDefinition.spec.object-templates[0].objectDefinition.spec.resourceHealthChecks[2].kind
+          value: Job

--- a/values.yaml
+++ b/values.yaml
@@ -68,6 +68,17 @@ acm:
   # -- MultiClusterHub spec (empty by default)
   mch_spec: {}
 
+  # -- Extra resource health checks to add to the spoke ArgoCD instance.
+  # Each entry needs group, kind, and check (Lua script) fields.
+  # @default -- empty list
+  extraResourceHealthChecks: []
+  # - group: argoproj.io
+  #   kind: Application
+  #   check: |
+  #     local health_status = {}
+  #     health_status.status = "Healthy"
+  #     return health_status
+
   # -- Just used for IIB testing, drives the source and channel for the MCE subscription triggered by ACM
   # @default -- Uses the official redhat sources
   mce_operator:


### PR DESCRIPTION
Tested with:
```
acm:
  extraResourceHealthChecks:
    - group: app
      kind: Deployment
      check: |
        hs = {}
        if obj.status ~= nil then
          if obj.status.readyReplicas == obj.status.replicas then
            hs.status = "Healthy"
          else
            hs.status = "Progressing"
          end
        end
        return hs
```

And correctly got the following on the spoke:
```
oc get argocd -n vp-gitops vp-gitops -o jsonpath='{.spec.resourceHealthChecks}' | jq -r '.[].kind'
Subscription
Deployment
```
