### PR TITLE
Add option to disable 2nd argocd

### DIFF
--- a/templates/policies/acm-hub-ca-policy.yaml
+++ b/templates/policies/acm-hub-ca-policy.yaml
@@ -2,6 +2,8 @@
 {{- if eq (include "acm.ishubcluster" .) "true" }}
 {{- range .Values.clusterGroup.managedClusterGroups }}
 {{- $group := . }}
+{{- if $.Values.global.singleArgoCD }}
+{{- else }}
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
@@ -65,6 +67,7 @@ spec:
   "clusterSelector" .clusterSelector
   "group" $group
   ) | nindent 2 }}
+{{- end }}{{/* if $.Values.global.singleArgoCD */}}
 {{- if (eq ((($.Values.global).secretStore).backend) "vault") }}
 ---
 apiVersion: policy.open-cluster-management.io/v1

--- a/templates/policies/application-policies.yaml
+++ b/templates/policies/application-policies.yaml
@@ -1,6 +1,10 @@
 # TODO: Also create a GitOpsCluster.apps.open-cluster-management.io
 {{- range .Values.clusterGroup.managedClusterGroups }}
 {{- $group := . }}
+{{- $argoDestNamespace := (printf "%s-%s" $.Values.global.pattern .name) -}}
+{{- if $.Values.global.singleArgoCD }}
+{{- $argoDestNamespace = $.Values.global.vpArgoNamespace -}}
+{{- end }}
 {{- if ($.Values.global.deletePattern | eq "DeleteSpoke" ) }}
 {{- else }}
 apiVersion: policy.open-cluster-management.io/v1
@@ -53,6 +57,8 @@ spec:
                 metadata:
                   name: {{ $.Values.global.pattern }}-{{ .name }}
                   namespace: {{ $.Values.global.vpArgoNamespace }}
+                  annotations:
+                    notice.argocd.argoproj.io/severity: critical
                   finalizers:
                   - resources-finalizer.argocd.argoproj.io/foreground
                 spec:
@@ -148,7 +154,10 @@ spec:
                   {{- end }}{{/* if $.Values.global.multiSourceSupport */}}
                   destination:
                     server: https://kubernetes.default.svc
-                    namespace: {{ $.Values.global.pattern }}-{{ .name }}
+                    namespace: {{ $argoDestNamespace }}
+                  info:
+                    - name: "VP"
+                      value: "https://validatedpatterns.io APP OF APPS"
                   syncPolicy:
                     automated:
                     {{- if ($.Values.global.deletePattern | ne "none" ) }}


### PR DESCRIPTION
This PR introduces the .Values.global.singleArgoCD boolean
which when set to true will use a single argoinstance for everything on
the cluster.

Co-Authored-By: Akos Eros <aeros@redhat.com>
Co-Authored-By: Michele Baldessari <michele@acksyn.org>
