### PR TITLE
Precreate default app

### DIFF
--- a/templates/policies/ocp-gitops-policy.yaml
+++ b/templates/policies/ocp-gitops-policy.yaml
@@ -137,6 +137,22 @@ spec:
             include:
               - default
           object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: argoproj.io/v1alpha1
+                kind: AppProject
+                metadata:
+                  name: default
+                  namespace: {{ $.Values.global.vpArgoNamespace }}
+                spec:
+                  clusterResourceWhitelist:
+                  - group: '*'
+                    kind: '*'
+                  destinations:
+                  - namespace: '*'
+                    server: '*'
+                  sourceRepos:
+                  - '*'
             - complianceType: mustonlyhave
               objectDefinition:
                 apiVersion: argoproj.io/v1beta1
@@ -275,6 +291,14 @@ spec:
 {{ .check | nindent 24 }}
 {{- end }}
                   server:
+                    initContainers:
+                    - command:
+                      - bash
+                      - -c
+                      - sleep 5
+                      image: registry.redhat.io/ubi9/ubi-minimal:latest
+                      name: wait-for-appproject
+                      resources: {}
                     autoscale:
                       enabled: false
                     grpc:

--- a/tests/ocp_gitops_policy_edge_cases_test.yaml
+++ b/tests/ocp_gitops_policy_edge_cases_test.yaml
@@ -19,13 +19,13 @@ tests:
           path: metadata.name
           value: group-one-gitops-policy-argocd
         equal:
-          path: spec.policy-templates[0].objectDefinition.spec.object-templates[0].objectDefinition.spec.server.route.tls.insecureEdgeTerminationPolicy
+          path: spec.policy-templates[0].objectDefinition.spec.object-templates[1].objectDefinition.spec.server.route.tls.insecureEdgeTerminationPolicy
           value: Allow
       - documentSelector:
           path: metadata.name
           value: group-one-gitops-policy-argocd
         equal:
-          path: spec.policy-templates[0].objectDefinition.spec.object-templates[0].objectDefinition.spec.server.route.tls.termination
+          path: spec.policy-templates[0].objectDefinition.spec.object-templates[1].objectDefinition.spec.server.route.tls.termination
           value: passthrough
 
   - it: should not include route TLS block when argocdServer is not configured
@@ -36,7 +36,7 @@ tests:
           path: metadata.name
           value: group-one-gitops-policy-argocd
         isNull:
-          path: spec.policy-templates[0].objectDefinition.spec.object-templates[0].objectDefinition.spec.server.route.tls
+          path: spec.policy-templates[0].objectDefinition.spec.object-templates[1].objectDefinition.spec.server.route.tls
 
   - it: should use default TLS values when tls block has a key but no overrides
     values:
@@ -53,13 +53,13 @@ tests:
           path: metadata.name
           value: group-one-gitops-policy-argocd
         equal:
-          path: spec.policy-templates[0].objectDefinition.spec.object-templates[0].objectDefinition.spec.server.route.tls.insecureEdgeTerminationPolicy
+          path: spec.policy-templates[0].objectDefinition.spec.object-templates[1].objectDefinition.spec.server.route.tls.insecureEdgeTerminationPolicy
           value: Redirect
       - documentSelector:
           path: metadata.name
           value: group-one-gitops-policy-argocd
         equal:
-          path: spec.policy-templates[0].objectDefinition.spec.object-templates[0].objectDefinition.spec.server.route.tls.termination
+          path: spec.policy-templates[0].objectDefinition.spec.object-templates[1].objectDefinition.spec.server.route.tls.termination
           value: reencrypt
 
   - it: should not include route TLS block when tls is empty map
@@ -75,7 +75,7 @@ tests:
           path: metadata.name
           value: group-one-gitops-policy-argocd
         isNull:
-          path: spec.policy-templates[0].objectDefinition.spec.object-templates[0].objectDefinition.spec.server.route.tls
+          path: spec.policy-templates[0].objectDefinition.spec.object-templates[1].objectDefinition.spec.server.route.tls
 
   - it: should render multiple groups each with their own set of resources
     set:
@@ -123,7 +123,7 @@ tests:
           path: metadata.name
           value: group-one-gitops-policy-argocd
         equal:
-          path: spec.policy-templates[0].objectDefinition.spec.object-templates[0].objectDefinition.spec.server.route.enabled
+          path: spec.policy-templates[0].objectDefinition.spec.object-templates[1].objectDefinition.spec.server.route.enabled
           value: true
 
   - it: should set default channel when neither spokeGitops nor main gitops is set

--- a/tests/ocp_gitops_policy_test.yaml
+++ b/tests/ocp_gitops_policy_test.yaml
@@ -104,25 +104,25 @@ tests:
           path: metadata.name
           value: group-one-gitops-policy-argocd
         lengthEqual:
-          path: spec.policy-templates[0].objectDefinition.spec.object-templates[0].objectDefinition.spec.resourceHealthChecks
+          path: spec.policy-templates[0].objectDefinition.spec.object-templates[1].objectDefinition.spec.resourceHealthChecks
           count: 2
       - documentSelector:
           path: metadata.name
           value: group-one-gitops-policy-argocd
         equal:
-          path: spec.policy-templates[0].objectDefinition.spec.object-templates[0].objectDefinition.spec.resourceHealthChecks[0].group
+          path: spec.policy-templates[0].objectDefinition.spec.object-templates[1].objectDefinition.spec.resourceHealthChecks[0].group
           value: operators.coreos.com
       - documentSelector:
           path: metadata.name
           value: group-one-gitops-policy-argocd
         equal:
-          path: spec.policy-templates[0].objectDefinition.spec.object-templates[0].objectDefinition.spec.resourceHealthChecks[0].kind
+          path: spec.policy-templates[0].objectDefinition.spec.object-templates[1].objectDefinition.spec.resourceHealthChecks[0].kind
           value: Subscription
       - documentSelector:
           path: metadata.name
           value: group-one-gitops-policy-argocd
         equal:
-          path: spec.policy-templates[0].objectDefinition.spec.object-templates[0].objectDefinition.spec.resourceHealthChecks[1].kind
+          path: spec.policy-templates[0].objectDefinition.spec.object-templates[1].objectDefinition.spec.resourceHealthChecks[1].kind
           value: PersistentVolumeClaim
 
   - it: Should append a single extra resource healthcheck
@@ -142,31 +142,31 @@ tests:
           path: metadata.name
           value: group-one-gitops-policy-argocd
         lengthEqual:
-          path: spec.policy-templates[0].objectDefinition.spec.object-templates[0].objectDefinition.spec.resourceHealthChecks
+          path: spec.policy-templates[0].objectDefinition.spec.object-templates[1].objectDefinition.spec.resourceHealthChecks
           count: 3
       - documentSelector:
           path: metadata.name
           value: group-one-gitops-policy-argocd
         equal:
-          path: spec.policy-templates[0].objectDefinition.spec.object-templates[0].objectDefinition.spec.resourceHealthChecks[0].group
+          path: spec.policy-templates[0].objectDefinition.spec.object-templates[1].objectDefinition.spec.resourceHealthChecks[0].group
           value: operators.coreos.com
       - documentSelector:
           path: metadata.name
           value: group-one-gitops-policy-argocd
         equal:
-          path: spec.policy-templates[0].objectDefinition.spec.object-templates[0].objectDefinition.spec.resourceHealthChecks[1].kind
+          path: spec.policy-templates[0].objectDefinition.spec.object-templates[1].objectDefinition.spec.resourceHealthChecks[1].kind
           value: PersistentVolumeClaim
       - documentSelector:
           path: metadata.name
           value: group-one-gitops-policy-argocd
         equal:
-          path: spec.policy-templates[0].objectDefinition.spec.object-templates[0].objectDefinition.spec.resourceHealthChecks[2].group
+          path: spec.policy-templates[0].objectDefinition.spec.object-templates[1].objectDefinition.spec.resourceHealthChecks[2].group
           value: argoproj.io
       - documentSelector:
           path: metadata.name
           value: group-one-gitops-policy-argocd
         equal:
-          path: spec.policy-templates[0].objectDefinition.spec.object-templates[0].objectDefinition.spec.resourceHealthChecks[2].kind
+          path: spec.policy-templates[0].objectDefinition.spec.object-templates[1].objectDefinition.spec.resourceHealthChecks[2].kind
           value: Application
 
   - it: Should append multiple extra resource healthchecks
@@ -194,29 +194,29 @@ tests:
           path: metadata.name
           value: group-one-gitops-policy-argocd
         lengthEqual:
-          path: spec.policy-templates[0].objectDefinition.spec.object-templates[0].objectDefinition.spec.resourceHealthChecks
+          path: spec.policy-templates[0].objectDefinition.spec.object-templates[1].objectDefinition.spec.resourceHealthChecks
           count: 4
       - documentSelector:
           path: metadata.name
           value: group-one-gitops-policy-argocd
         equal:
-          path: spec.policy-templates[0].objectDefinition.spec.object-templates[0].objectDefinition.spec.resourceHealthChecks[1].kind
+          path: spec.policy-templates[0].objectDefinition.spec.object-templates[1].objectDefinition.spec.resourceHealthChecks[1].kind
           value: PersistentVolumeClaim
       - documentSelector:
           path: metadata.name
           value: group-one-gitops-policy-argocd
         equal:
-          path: spec.policy-templates[0].objectDefinition.spec.object-templates[0].objectDefinition.spec.resourceHealthChecks[2].group
+          path: spec.policy-templates[0].objectDefinition.spec.object-templates[1].objectDefinition.spec.resourceHealthChecks[2].group
           value: argoproj.io
       - documentSelector:
           path: metadata.name
           value: group-one-gitops-policy-argocd
         equal:
-          path: spec.policy-templates[0].objectDefinition.spec.object-templates[0].objectDefinition.spec.resourceHealthChecks[3].group
+          path: spec.policy-templates[0].objectDefinition.spec.object-templates[1].objectDefinition.spec.resourceHealthChecks[3].group
           value: batch
       - documentSelector:
           path: metadata.name
           value: group-one-gitops-policy-argocd
         equal:
-          path: spec.policy-templates[0].objectDefinition.spec.object-templates[0].objectDefinition.spec.resourceHealthChecks[3].kind
+          path: spec.policy-templates[0].objectDefinition.spec.object-templates[1].objectDefinition.spec.resourceHealthChecks[3].kind
           value: Job

--- a/tests/vp_argo_namespace_gitops_test.yaml
+++ b/tests/vp_argo_namespace_gitops_test.yaml
@@ -99,13 +99,13 @@ tests:
           path: metadata.name
           value: group-one-gitops-policy-argocd
         equal:
-          path: spec.policy-templates[0].objectDefinition.spec.object-templates[0].objectDefinition.metadata.name
+          path: spec.policy-templates[0].objectDefinition.spec.object-templates[1].objectDefinition.metadata.name
           value: custom-argocd
       - documentSelector:
           path: metadata.name
           value: group-one-gitops-policy-argocd
         equal:
-          path: spec.policy-templates[0].objectDefinition.spec.object-templates[0].objectDefinition.metadata.namespace
+          path: spec.policy-templates[0].objectDefinition.spec.object-templates[1].objectDefinition.metadata.namespace
           value: custom-argocd
 
   - it: should use default vpArgoNamespace for ArgoCD resource name and namespace
@@ -116,13 +116,13 @@ tests:
           path: metadata.name
           value: group-one-gitops-policy-argocd
         equal:
-          path: spec.policy-templates[0].objectDefinition.spec.object-templates[0].objectDefinition.metadata.name
+          path: spec.policy-templates[0].objectDefinition.spec.object-templates[1].objectDefinition.metadata.name
           value: openshift-gitops
       - documentSelector:
           path: metadata.name
           value: group-one-gitops-policy-argocd
         equal:
-          path: spec.policy-templates[0].objectDefinition.spec.object-templates[0].objectDefinition.metadata.namespace
+          path: spec.policy-templates[0].objectDefinition.spec.object-templates[1].objectDefinition.metadata.namespace
           value: openshift-gitops
 
   - it: should create ConsoleLink when vpArgoNamespace is not openshift-gitops
@@ -137,30 +137,30 @@ tests:
           value: group-one-gitops-policy-argocd
         lengthEqual:
           path: spec.policy-templates[0].objectDefinition.spec.object-templates
-          count: 2
+          count: 3
       - documentSelector:
           path: metadata.name
           value: group-one-gitops-policy-argocd
         equal:
-          path: spec.policy-templates[0].objectDefinition.spec.object-templates[1].objectDefinition.kind
+          path: spec.policy-templates[0].objectDefinition.spec.object-templates[2].objectDefinition.kind
           value: ConsoleLink
       - documentSelector:
           path: metadata.name
           value: group-one-gitops-policy-argocd
         equal:
-          path: spec.policy-templates[0].objectDefinition.spec.object-templates[1].objectDefinition.metadata.name
+          path: spec.policy-templates[0].objectDefinition.spec.object-templates[2].objectDefinition.metadata.name
           value: custom-argocd-gitops-link
       - documentSelector:
           path: metadata.name
           value: group-one-gitops-policy-argocd
         equal:
-          path: spec.policy-templates[0].objectDefinition.spec.object-templates[1].objectDefinition.spec.location
+          path: spec.policy-templates[0].objectDefinition.spec.object-templates[2].objectDefinition.spec.location
           value: ApplicationMenu
       - documentSelector:
           path: metadata.name
           value: group-one-gitops-policy-argocd
         equal:
-          path: spec.policy-templates[0].objectDefinition.spec.object-templates[1].objectDefinition.spec.text
+          path: spec.policy-templates[0].objectDefinition.spec.object-templates[2].objectDefinition.spec.text
           value: Argo CD VP
 
   - it: should NOT create ConsoleLink when vpArgoNamespace is openshift-gitops
@@ -172,7 +172,7 @@ tests:
           value: group-one-gitops-policy-argocd
         lengthEqual:
           path: spec.policy-templates[0].objectDefinition.spec.object-templates
-          count: 1
+          count: 2
 
   - it: should have 3 object-templates with custom vpArgoNamespace and no gitOpsSubNamespace
     values:


### PR DESCRIPTION
So, finally, after our PR [1] landed into gitops-1.21 (argo 3.4.3) we
still got a few InvalidSpecError on the spoke's argo here and there.

After the initial surprise, it turns out that this race condition has
the same error message but is not the one we addressed in the PR [1].

In fact without PR [1] you could add a delay to the argocd instance
and/or precreate the default AppProject but nothing would help because
the InformerCache was already populated and only a manual sync/argocd
restart would fix things.

With PR [1] now merged, precreating the default AppProject absolutely
does fix things. I have added also a 5 seconds startup delay to ArgoCD
for good measure (Note: while I could add some code in the initContainer
that checks for the default appproject, I prefer just a super simple 5
seconds timeout)

Tested this patch and got about ~40 successful deployments in a row.

[1] www.github.com/argoproj/argo-cd/pull/27672
